### PR TITLE
Add Search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rails-assets.org'
 
 gem 'rails', '5.0.2'
 gem 'pg'
+gem 'pg_search'
 gem 'puma'
 gem 'redis'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,6 +167,10 @@ GEM
       activerecord (>= 4.0, < 5.2)
       request_store (~> 1.1)
     pg (0.20.0)
+    pg_search (2.0.1)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
+      arel (>= 6)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -304,6 +308,7 @@ DEPENDENCIES
   omniauth-google-oauth2
   paper_trail
   pg
+  pg_search
   pry-byebug
   pry-rails
   pry-rescue

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -67,3 +67,24 @@ nav img.avatar {
     padding-top: 1em;
   }
 }
+
+.navbar input.form-control {
+  background-color: rgba(255, 255, 255, 0.3);
+  color: white;
+}
+
+
+.search-box {
+  background-color: #f7f7f9;
+  padding-top: 1.5rem;
+  padding-bottom: 1.5rem;
+}
+.search-result {
+  border-bottom: thin solid #f7f7f9;
+}
+.search-preview {
+  text-overflow: ellipsis;
+}
+.search-preview strong {
+  background-color: yellow;
+}

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,0 +1,17 @@
+class SearchController < ApplicationController
+  def show
+    @query = params[:q]
+
+    if @query
+      @results = PgSearch.multisearch(@query)
+
+      case params[:t]
+      when "Page"
+        @results = @results.where(searchable_type: "Page")
+      when "Gist"
+        @results = @results.where(searchable_type: ["Gist", "GistFile"])
+      end
+    end
+  end
+
+end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,0 +1,9 @@
+module SearchHelper
+  def model_type_checked(model)
+    if model == params.fetch(:t) { "Any" }
+      "checked"
+    else
+      nil
+    end
+  end
+end

--- a/app/models/gist.rb
+++ b/app/models/gist.rb
@@ -4,6 +4,9 @@ class Gist < ActiveRecord::Base
   accepts_nested_attributes_for :gist_files
   validates_presence_of :description
 
+  include PgSearch
+  multisearchable against: [:description]
+
   def user_name
     user&.name || "Nobody"
   end

--- a/app/models/gist_file.rb
+++ b/app/models/gist_file.rb
@@ -1,3 +1,6 @@
 class GistFile < ActiveRecord::Base
   belongs_to :gist
+
+  include PgSearch
+  multisearchable against: [:body, :file_name]
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -2,4 +2,9 @@ class Page < ActiveRecord::Base
   validates_presence_of :body, :path
   validates_uniqueness_of :path
   has_paper_trail
+
+  include PgSearch
+  multisearchable against: [:title, :body, :path]
+
+  pg_search_scope :search_for, against: [:path, :body]
 end

--- a/app/views/application/_navbar.html.slim
+++ b/app/views/application/_navbar.html.slim
@@ -14,6 +14,8 @@
             a.nav-link href=new_page_path New Page
           li.nav-item class=active_if("gists/new")
             a.nav-link href=new_gist_path New Gist
+        form.form-inline action=search_path method="get"
+          input.form-control.mr-sm-2 name="q" placeholder="Search" type="text" /
         ul.navbar-nav.pull-right
           li.nav-item.dropdown
             a#dropdown02.nav-link  aria-expanded="false" aria-haspopup="true" data-toggle="dropdown" href=signout_path

--- a/app/views/search/_result_gist.html.slim
+++ b/app/views/search/_result_gist.html.slim
@@ -1,0 +1,7 @@
+.row
+  .col-1
+    .pull-right
+      = fa_icon "code"
+  .col-11
+    h4 = link_to result.description, result
+

--- a/app/views/search/_result_gist_file.html.slim
+++ b/app/views/search/_result_gist_file.html.slim
@@ -1,0 +1,2 @@
+-# Just render the parent gist view
+= render partial: "result_gist", locals: {result: result.gist, document: document}

--- a/app/views/search/_result_page.html.slim
+++ b/app/views/search/_result_page.html.slim
@@ -1,0 +1,6 @@
+.row
+  .col-1
+    .pull-right
+      = fa_icon "file-text-o"
+  .col-11
+    h4 = link_to "/" + result.path, display_page_path(result)

--- a/app/views/search/show.html.slim
+++ b/app/views/search/show.html.slim
@@ -1,0 +1,40 @@
+.container.search-box
+  form action=search_path method="get"
+    .form-group.row
+      .col-sm-10
+        input#search_field.form-control.mr-sm-2 name="q" placeholder="Search" type="text" value=@query
+      .col-sm-2
+        input.btn.btn-primary type="submit" value="Search"
+    .form-group.row
+      .col-sm-12
+        label.custom-control.custom-radio
+          input#t_any.custom-control-input name="t" type="radio" value="Any" checked=model_type_checked("Any")
+          span.custom-control-indicator
+          span.custom-control-description Anything
+        label.custom-control.custom-radio
+          input#t_page.custom-control-input name="t" type="radio" value="Page" checked=model_type_checked("Page")
+          span.custom-control-indicator
+          span.custom-control-description Pages
+        label.custom-control.custom-radio
+          input#t_gist.custom-control-input name="t" type="radio" value="Gist" checked=model_type_checked("Gist")
+          span.custom-control-indicator
+          span.custom-control-description Gists
+
+
+br
+- if @results
+  .search-query
+    | Showing results for
+    code
+      = @query
+
+  .search-results
+    - @results&.each do |result|
+      p.search-result
+        = render partial: "result_#{result.searchable_type.underscore}", locals: {result: result.searchable, document: result}
+        .row
+          .push-1.col-11
+            pre.search-preview.small.text-muted
+              - result.content.lines.each_with_index do |line, index|
+                - if line.include? @query
+                  | #{'%3.3s' % index}: #{raw line.gsub(@query, "<strong>#{@query}</strong>")}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+
   root 'welcome#index'
 
   resources :pages do
@@ -13,6 +14,7 @@ Rails.application.routes.draw do
   get '/directory', to: "directory#index"
   get '/directory/:id', to: "directory#show"
   post 'preview', to: 'preview#show'
+  get '/search', to: 'search#show'
 
   get 'welcome/auth'
   get '/auth/:provider/callback', to: 'sessions#create'

--- a/db/migrate/20170602145920_create_pg_search_documents.rb
+++ b/db/migrate/20170602145920_create_pg_search_documents.rb
@@ -1,0 +1,17 @@
+class CreatePgSearchDocuments < ActiveRecord::Migration
+  def self.up
+    say_with_time("Creating table for pg_search multisearch") do
+      create_table :pg_search_documents do |t|
+        t.text :content
+        t.belongs_to :searchable, :polymorphic => true, :index => true
+        t.timestamps null: false
+      end
+    end
+  end
+
+  def self.down
+    say_with_time("Dropping table for pg_search multisearch") do
+      drop_table :pg_search_documents
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170508144141) do
+ActiveRecord::Schema.define(version: 20170602145920) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,6 +40,15 @@ ActiveRecord::Schema.define(version: 20170508144141) do
     t.text     "body"
     t.datetime "created_at"
     t.datetime "updated_at"
+  end
+
+  create_table "pg_search_documents", force: :cascade do |t|
+    t.text     "content"
+    t.string   "searchable_type"
+    t.integer  "searchable_id"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+    t.index ["searchable_type", "searchable_id"], name: "index_pg_search_documents_on_searchable_type_and_searchable_id", using: :btree
   end
 
   create_table "uploads", force: :cascade do |t|

--- a/spec/features/full_text_search_spec.rb
+++ b/spec/features/full_text_search_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+feature 'full text search' do
+
+  let!(:amy) { User.create! name: "Amy Pond" }
+
+  before do
+    sign_in amy
+
+    10.times do |i|
+      Page.create! path: "numbered/page/#{i}", body: "Page #{i} body"
+      Gist.create! description: "Gist #{i}",
+        gist_files: [GistFile.new(file_type: "md",
+                                 body: "Gist #{i} body")]
+    end
+
+  end
+
+  scenario 'find pages and gists with word in the body' do
+    visit search_path
+    fill_in "search_field", with: "body"
+    click_button "Search"
+    expect(find(".search-results")).to have_text("Page 1 body")
+    expect(find(".search-results")).to have_text("Gist 1 body")
+  end
+
+  scenario 'find pages with word in the path' do
+    visit search_path
+    fill_in "search_field", with: "numbered/page/1"
+    click_button "Search"
+    expect(find(".search-results")).to have_text("numbered/page/1")
+  end
+
+  scenario 'find only pages with word in the body' do
+    visit search_path
+    fill_in "search_field", with: "body"
+    choose "t_page"
+    click_button "Search"
+    expect(find(".search-results")).to have_text("Page 1 body")
+    expect(find(".search-results")).to_not have_text("Gist 1 body")
+  end
+
+  scenario 'find only pages with word in the body' do
+    visit search_path
+    fill_in "search_field", with: "body"
+    choose "t_page"
+    click_button "Search"
+    expect(find(".search-results")).to have_text("Page 1 body")
+    expect(find(".search-results")).to_not have_text("Gist 1 body")
+  end
+
+  scenario 'find only gists with word in the body' do
+    visit search_path
+    fill_in "search_field", with: "body"
+    choose "t_gist"
+    click_button "Search"
+    expect(find(".search-results")).to_not have_text("Page 1 body")
+    expect(find(".search-results")).to have_text("Gist 1 body")
+  end
+
+end

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the SearchHelper. For example:
+#
+# describe SearchHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe SearchHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
This adds the `pg_search` gem to do full text search across pages, gists and gist files. The form was manually created in the view to submit via a GET with query parameters:

- `q` The query
- `t` The type: page, gist, or any

Since the controller relies on the `PgSearch` class all the testing was done via feature specs.