### PR TITLE
Add anchor links when hovering on a title on wiki pages

### DIFF
--- a/app/assets/javascripts/pages.js.coffee
+++ b/app/assets/javascripts/pages.js.coffee
@@ -3,7 +3,6 @@
 # You can use CoffeeScript in this file: http://coffeescript.org/
 
 $ ->
-
   $('a#preview_tab[data-toggle="tab"]').on 'shown.bs.tab', (e) ->
     data = body: $('#page_body').val()
     $('#preview_area').html '<div class="fa fa-gear fa-spin"></div>'
@@ -16,3 +15,9 @@ $ ->
         $('#preview_area').html "Unable to render preview"
       success: (data, textStatus, jqXHR) ->
         $('#preview_area').html data
+
+  $('h1[id],h2[id],h3[id],h4[id],h5[id],h6[id]').each (index, element) =>
+    anchor = "#" + $(element).attr("id")
+    text = '<i class="fa fa-link" aria-hidden="true"></i>'
+    link = '<a class="anchor" href="'+anchor+'">'+text+'</a>'
+    $(element).append(link)

--- a/app/assets/stylesheets/_markdown.scss
+++ b/app/assets/stylesheets/_markdown.scss
@@ -27,13 +27,30 @@
   img {
     max-width: 100% !important;
   }
-}
 
+  h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
+    margin-bottom: 0.9rem;
+  }
+
+}
 
 .markdown .highlight pre, .hll{
   background-color: #f8f8f8;
   border: 1px solid #ccc;
   padding: 6px 10px;
   border-radius: 3px;
+}
+
+h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
+  &:hover > .anchor{
+    display: inline;
+  }
+  .anchor {
+    color: #eee;
+    display: none;
+    font-size: 0.8em;
+    margin-left: 0.2em;
+    line-height: 1;
+  }
 }
 

--- a/app/models/renderer.rb
+++ b/app/models/renderer.rb
@@ -30,17 +30,18 @@ class Renderer
   end
 
   def render_markdown(body)
-    markdown = Redcarpet::Markdown.new(HTMLwithPygments,
-                                        autolink: true,
-                                        fenced_code_blocks: true,
-                                        footnotes: true,
-                                        hard_wrap: true,
-                                        lax_spacing: true,
-                                        no_intra_emphasis: true,
-                                        space_after_headers: true,
-                                        strikethrough: true,
-                                        tables: true
-                                       )
+    renderer = HTMLwithPygments.new(with_toc_data: true)
+    markdown = Redcarpet::Markdown.new(renderer,
+                                       autolink: true,
+                                       fenced_code_blocks: true,
+                                       footnotes: true,
+                                       hard_wrap: true,
+                                       lax_spacing: true,
+                                       no_intra_emphasis: true,
+                                       space_after_headers: true,
+                                       strikethrough: true,
+                                       tables: true
+                                      )
     emojify(markdown.render(body))
   end
 

--- a/spec/requests/preview_request_spec.rb
+++ b/spec/requests/preview_request_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Pages", :type => :request do
     it "renders markdown content" do
       sign_in rory
       post preview_path, params: valid_attributes
-      expect(response.body).to include "<h1>"
+      expect(response.body).to include '<h1 id="header-1">'
     end
   end
 end


### PR DESCRIPTION
This give a light gray link icon next to the title when the mouse is hovered over the title, making it easy to get a link directly to a section of the page.

### No hover:
![image](https://user-images.githubusercontent.com/16963/27012108-e2f92c82-4e97-11e7-8da8-1cae121ce516.png)

### With hover:
![image](https://user-images.githubusercontent.com/16963/27012111-ea0a24f4-4e97-11e7-8c52-c3918a04695f.png)
