### PR TITLE
Select files to upload

### DIFF
--- a/app/assets/javascripts/uploads.coffee
+++ b/app/assets/javascripts/uploads.coffee
@@ -7,4 +7,14 @@ $ ->
     extraParams:
       authenticity_token: $('meta[name="csrf-token"]').attr( 'content' )
 
+  $('#upload_link').click (event)->
+    $('#upload_file').trigger("click")
+    event.preventDefault()
+  $(document).on 'change','#upload_file', ()->
+    $('form#new_upload').submit()
+
+  # Callback for the iframe upload
+  window.handle_iframe_upload = (details)->
+    textarea = $('#page_body')
+    textarea.val(textarea.val() + '\n\n' + details)
 

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -34,7 +34,7 @@ class Upload < ActiveRecord::Base
     end
 
     def create_with_file(file, user)
-      self.new.create_with_file(file, user)
+      new.create_with_file(file, user)
     end
   end
 
@@ -46,6 +46,14 @@ class Upload < ActiveRecord::Base
     self.url = self.class.processor.new(file).run
 
     self
+  end
+
+  def image?
+    %w[image/jpeg image/png image/jpg image/gif].include? file_type
+  end
+
+  def markdown_link
+    "#{"!" if image?}[#{file_name}](#{url})"
   end
 end
 

--- a/app/views/pages/_form.html.slim
+++ b/app/views/pages/_form.html.slim
@@ -28,7 +28,10 @@
               | -
               =<> link_to "Older Versions", versions_page_path(page)
           - if Upload.enabled?
-            span Attach files by dragging & dropping, or pasting from the clipboard.
+            span
+              | Attach files by dragging & dropping,
+              a#upload_link< href="#" selecting them
+              | , or pasting from the clipboard.
           span<>
             | Markdown supported.
     #preview.tab-pane role="tabpanel"
@@ -43,3 +46,9 @@
           = fa_icon 'save', text: "Save"
       - if page.persisted?
         =<> link_to fa_icon("trash-o", text: "Delete"), page, data: {:confirm => 'Are you sure?'}, :method => :delete, class: "btn btn-danger"
+
+div style="display:none"
+  iframe id="upload_frame" name="upload_frame" style="display: none"
+  == form_for @upload=Upload.new, html: {target: :upload_frame} do |f|
+    = f.file_field :file
+    input type="hidden" name="strategy" value="iframe"

--- a/app/views/uploads/create.html.erb
+++ b/app/views/uploads/create.html.erb
@@ -1,0 +1,7 @@
+<html>
+  <head>
+    <script>
+      parent.handle_iframe_upload('<%= raw @upload.markdown_link %>');
+    </script>
+  </head>
+</html>

--- a/app/views/uploads/new.html.slim
+++ b/app/views/uploads/new.html.slim
@@ -13,13 +13,13 @@
         .panel-footer.clearfix
           = f.submit class: "btn btn-sm pull-right btn-primary"
           - if @upload.persisted?
-            = link_to 'Cancel', upload_path(@upload), class: "btn btn-sm btn-default"
+            = link_to 'cancel', upload_path(@upload), class: "btn btn-sm btn-default"
           - else
-            = link_to 'Cancel', uploads_path, class: "btn btn-sm btn-default"
+            = link_to 'cancel', uploads_path, class: "btn btn-sm btn-default"
           - unless false || @upload.new_record?
             = link_to \
-                  'Delete',
+                  'delete',
                   upload_path(@upload),
                   class: "btn btn-sm btn-danger",
                   method: 'delete',
-                  data: { confirm: 'Are you sure you want to delete this upload?' }
+                  data: { confirm: 'are you sure you want to delete this upload?' }

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -45,8 +45,23 @@ RSpec.describe Gist, type: :model do
       uploader = UploadProcessors::Filesystem.new(tardis)
       upload = Upload.create_with_file(tardis, rory)
       expect(upload.valid?).to be true
-      expect(upload.url).to match /\/uploads\/.*\.png/
+      expect(upload.url).to match(/\/uploads\/.*\.png/)
     end
+  end
 
+  it "puts a bang on an image markdown link" do
+    upload = Upload.new url: "https://example.com/image.png",
+                        file_name: "png",
+                        file_type: "image/png"
+
+    expect(upload.markdown_link).to eq "![png](https://example.com/image.png)"
+  end
+
+  it "formats a markdown link" do
+    upload = Upload.new url: "https://example.com/file.zip",
+                        file_name: "zip",
+                        file_type: "application/zip"
+
+    expect(upload.markdown_link).to eq "[zip](https://example.com/file.zip)"
   end
 end

--- a/spec/requests/upload_request_spec.rb
+++ b/spec/requests/upload_request_spec.rb
@@ -55,4 +55,16 @@ RSpec.describe "Uploads", type: :request do
     end
   end
 
+  describe "POST iframe create" do
+    it "renders the javascript callback into the page" do
+      sign_in rory
+
+      post uploads_path, params: {upload: valid_attributes, strategy: "iframe"}
+
+      # This is a ejs-like callback that happens when the form posts to the
+      # iframe directly. See uploads.coffee for details.
+      expect(response.body).to include "parent.handle_iframe_upload("
+
+    end
+  end
 end


### PR DESCRIPTION
This allows uploading of files by clicking and browsing for files to upload. This does some EJS-like processing:

On `pages/_form` added:

  - hidden upload form
  - hidden iframe

Then when the user needs to upload a file it is posted to the iframe which submits the original action (via the frame target attribute).

The form has a special strategy parameter to indicate to the action that it is special, and should render a view that is expected in this iframe post.

The upload is processed and the special view is rendered in the iframe.  This contains some javascript that is run as the page is loaded to call back to the parent page and indicate the upload has processed.

That callback (parent.handle_iframe_upload) will then take the details of the upload (in this case "details" means the markdown link) and update the text area for the page.