### PR TITLE
updates readme and env example

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -15,11 +15,11 @@
 # Create new Project -> APIs and Auth - Credentials -> Create new Client ID -> Web Application
 #
 # In AUTHORIZED REDIRECT URI add the following
-#    http://localhost:3000/
-#    http://tool.my-domain.com/
-# In AUTHORIZED JAVASCRIPT ORIGINS add the following:
 #    http://localhost:3000/auth/google/callback
 #    http://tool.my-domain.com/auth/google/callback
+# In AUTHORIZED JAVASCRIPT ORIGINS add the following:
+#    http://localhost:3000
+#    http://tool.my-domain.com
 #
 # Make sure you enable the API for "Google+" for that app as well, or you will
 # get a "Access Not Configured. Please use Google Developers Console to

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Corporate Tool uses [OmniAuth](https://github.com/omniauth/omniauth) to authenti
 - `GOOGLE_CLIENT_SECRET` - Google OAuth Client Secret Key
 - `GOOGLE_HOME_DOMAIN` - Optional: Restrict access to only this Google apps domain
 
-See [`.env-example`](/.env-example) for instructions for setting up the cerdentials, and examples and, a full list of settings.
+See [`.env-example`](/.env-example) for instructions for setting up the credentials, and examples and, a full list of settings.
 
 # License
 


### PR DESCRIPTION
There was a spelling error in the readme and the env-example file had the google configuration instructions slightly incorrect. I updated these so future folks have an easier time setting up the application locally.