### PR TITLE
Update rack

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,7 +196,7 @@ GEM
       pry (>= 0.9.11)
     public_suffix (3.0.2)
     puma (3.11.4)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-test (1.0.0)
       rack (>= 1.0, < 3)
     rails (5.2.0)


### PR DESCRIPTION
Known moderate severity security vulnerability detected in rack >= 2.0.4, < 2.0.6 defined in Gemfile.lock.

Gemfile.lock update suggested: rack ~> 2.0.6.