### PR TITLE
Add Mermaid Support

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -26,5 +26,6 @@
 
 //= require inline-attachment
 //= require jquery.inline-attachment
+//= require mermaid
 //= require_tree .
 

--- a/app/assets/javascripts/pages.js
+++ b/app/assets/javascripts/pages.js
@@ -8,28 +8,31 @@
 // You can use CoffeeScript in this file: http://coffeescript.org/
 
 $(function() {
+  mermaid.initialize({ startOnLoad: true });
+
   $('a#preview_tab[data-toggle="tab"]').on('shown.bs.tab', function(e) {
     const data = {body: $('#page_body').val()};
     $('#preview_area').html('<div class="fa fa-gear fa-spin"></div>');
 
-    return $.ajax({
+    $.ajax({
       url: '/preview',
       data,
       type: 'POST',
       error(jqXHR, textStatus, errorThrown) {
-        return $('#preview_area').html("Unable to render preview");
+        $('#preview_area').html("Unable to render preview");
       },
       success(data, textStatus, jqXHR) {
-        return $('#preview_area').html(data);
+        $('#preview_area').html(data);
+        mermaid.init();
       }
     });
   });
 
-  return $('h1[id],h2[id],h3[id],h4[id],h5[id],h6[id]').each((index, element) => {
+  $('h1[id],h2[id],h3[id],h4[id],h5[id],h6[id]').each((index, element) => {
     const anchor = "#" + $(element).attr("id");
     const text = '<i class="fa fa-link" aria-hidden="true"></i>';
     const link = '<a class="anchor" href="'+anchor+'">'+text+'</a>';
-    return $(element).append(link);
+    $(element).append(link);
   });
 });
 

--- a/app/assets/javascripts/uploads.js
+++ b/app/assets/javascripts/uploads.js
@@ -1,8 +1,3 @@
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 // Place all the behaviors and hooks related to the matching controller here.
 // All this logic will automatically be available in application.js.
 // You can use CoffeeScript in this file: http://coffeescript.org/
@@ -16,14 +11,14 @@ $(function() {
 
   $('#upload_link').click(function(event){
     $('#upload_file').trigger("click");
-    return event.preventDefault();
+    event.preventDefault();
   });
   $(document).on('change','#upload_file', () => $('form#new_upload').submit());
 
   // Callback for the iframe upload
-  return window.handle_iframe_upload = function(details){
+  window.handle_iframe_upload = function(details){
     const textarea = $('#page_body');
-    return textarea.val(textarea.val() + '\n\n' + details);
+    textarea.val(textarea.val() + '\n\n' + details);
   };
 });
 

--- a/app/assets/stylesheets/_pages.scss
+++ b/app/assets/stylesheets/_pages.scss
@@ -45,3 +45,7 @@
     font-size: 3em;
   }
 }
+
+div.mermaid {
+  display: block;
+}

--- a/app/models/renderer.rb
+++ b/app/models/renderer.rb
@@ -1,3 +1,5 @@
+require 'kramdown-mermaid-rouge'
+
 class Renderer
   def self.markdown(body)
     new.render_markdown(body).html_safe unless body.empty?
@@ -22,7 +24,7 @@ class Renderer
   end
 
   def render_markdown(body)
-    opts = { input: 'GFM', syntax_highlighter: :rouge }
+    opts = { input: 'GFM', syntax_highlighter: :mermaid_rouge}
     emojify(Kramdown::Document.new(body, opts).to_html)
   end
 end

--- a/app/views/pages/show.html.slim
+++ b/app/views/pages/show.html.slim
@@ -1,5 +1,6 @@
 - content_for :title do
   = @page.path
+
 - if @version
   .alert.alert-warning role="alert"
     |

--- a/lib/kramdown-mermaid-rouge.rb
+++ b/lib/kramdown-mermaid-rouge.rb
@@ -1,0 +1,37 @@
+require 'kramdown'
+require 'kramdown/converter/syntax_highlighter/rouge'
+
+module Kramdown
+  module Options
+    define(:enable_mermaid, Boolean, true, "Enable Mermaid wrapped Rouge SyntaxHighlighting")
+  end
+
+  module Converter #:nodoc:
+    module SyntaxHighlighter #:nodoc:
+      module MermaidRouge
+        extend ::Kramdown::Utils::Configurable
+
+        VERSION = '0.0.1'
+
+        def self.call(converter, text, lang, type, call_opts)
+          return nil unless converter.options[:enable_mermaid]
+          if lang && lang == "mermaid"
+            "<div class=\"mermaid\">\n" << text << "\n</div>"
+          else
+            SyntaxHighlighter::Rouge.call(converter, text, lang, type, call_opts)
+          end
+        rescue StandardError
+          converter.warning("There was an error using Mermaid or Rouge: #{$!.message}")
+          "<div class='alert alert-warning'>#{ $!.message }</div>"
+        end
+
+        def self.options(converter, type)
+          nil
+        end
+      end
+
+    end
+    add_syntax_highlighter(:mermaid_rouge, SyntaxHighlighter::MermaidRouge)
+  end
+end
+

--- a/spec/features/user_google_sign_in_spec.rb
+++ b/spec/features/user_google_sign_in_spec.rb
@@ -23,7 +23,7 @@ feature 'Sign in via Google' do
 
 
     visit root_path
-    click_link 'Login with Google'
+    click_button 'Login with Google'
     expect(find('body')).to have_content('Signed in')
   end
 

--- a/spec/models/renderer_spec.rb
+++ b/spec/models/renderer_spec.rb
@@ -12,8 +12,20 @@ RSpec.describe Renderer, type: :model do
   it "renders a code span" do
     body = renderer.render_markdown("`x = Class.new`{:.language-ruby}")
 
-    expect(body).to include("language-ruby highlighter-rouge")
+    expect(body).to include("language-ruby highlighter-mermaid_rouge")
   end
+
+  it "renders a mermaid div" do
+    body = renderer.render_markdown <<~MARKDOWN
+      ```mermaid
+        graph TD
+        A[Markdown] --> B[Mermaid Graph]
+      ```
+    MARKDOWN
+
+    expect(body).to include("<div class=\"mermaid\">")
+  end
+
 
   it "renders fenced codeblock" do
     body = renderer.render_markdown <<~MARKDOWN


### PR DESCRIPTION
This adds support for [Mermaid.js][1] so we can render graphs in the wiki pages by entering the mermaid markup in fenced code blocks:

    ```mermaid
    graph TD
    A[Mardown Example] --> B[Fancy Graph]
    ````

Becomes: 
```mermaid
graph TD
A[Mardown Example] --> B[Fancy Graph]
````

This works because code blocks with the "mermaid" language will be rendered into a `<div class=\"mermaid\">` tag, which the mermaid.js will detect and replace the contents in the DOM with the SVG of the graph.

Since I couldn't add multiple syntax highlighters to Kramdown I had to make a new one that would wrap the existing Rouge syntax highlighter, intercept anything with Mermaid, and pass on the rest to Rouge. Kinda clunky, but seems to work well.

Preview was a little tricky since the rendered markdown is dynamically injected into the page. But turns out you can call `mermaid.init()` multiple times and it will happily re-run on the page.

[1]: https://mermaid-js.github.io
